### PR TITLE
Be more liberal in detecting NOSCRIPT error

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ Shavaluator.prototype.execWithClient = function(redisClient, name, keys, args, c
   var params = [script.hash, keys.length].concat(keys).concat(args);
   redisClient.evalsha(params, function(err, res) {
     if (err) {
-      if (/^NOSCRIPT /.test(err.message)) {
+      if (/NOSCRIPT/.test(err.message)) {
         var params = [script.body, keys.length].concat(keys).concat(args);
         redisClient.send_command('eval', params, callback);
       } else {


### PR DESCRIPTION
Our redis client (with sentinel) is sending err.message as:
`Error: NOSCRIPT No matching script. Please use EVAL.`
Causing the NOSCRIPT detection to fail.

This was with the following installed:

```
$ npm ls | grep redis
├─┬ hiredis@0.1.16
│ │ ├── redis@0.7.3
├── redis-evalsha@1.1.0
├─┬ redis-sentinel-client@0.1.5 (git://github.com/Exocortex/node-redis-sentinel-client#27093cee573dd23ffd9dd0ab954b8581efbd6ad1)
│ └── redis@0.8.4
```
